### PR TITLE
Added function to work on CycIF images

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ palom.pyramid.write_pyramid(
 )
 ```
 
-### For OME-TIFF files
+### For TIFF and OME-TIFF files
 
 ```python
 import palom

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Running the following command would generate the configuration file
 palom-cycif-helper -i "Y:/user/me/projects/data/cycif/raw" -n "*cycle1*" -o "Y:/user/me/projects/data/cycif/palom/mosaic.ome.tiff" -c "Y:/user/me/projects/data/cycif/palom/config.yaml"
 ```
 
-And running the `palom-cycif` command on the resulting configuration file would produce the output mosaic `ome.tiff` file.
+And running the `palom-cycif` command on the resulting configuration file would produce the output pyramidal `ome.tiff` file and PNG files showing feature-based registration results and a log file.
 
 ```bash
 palom-cycif run -c "Y:/user/me/projects/data/cycif/palom/config.yaml"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,67 @@ Y:\DATA\SARDANA\MIHC\768473\RAW
             06-CBB_SARDANA_768473_C04R1_CD8.svs.png
             768473.ome.tif.log
 ```
+### CLI for TIFF and OME-TIFF files
+
+Palom can also merge multiple TIFF or OME-TIFF files into a pyramidal OME-TIFF 
+file with the requirement of a user-defined configuration YAML file.
+
+A configuration example can be printed to the console by running
+
+```bash
+palom-cycif show example
+```
+
+```yaml
+input dir: Y:/user/me/projects/data/cycif
+output full path: Y:/user/me/projects/analysis/cycif/2022/example-output.ome.tiff
+
+pixel size: 0.325
+
+reference image:
+    filename: 20220413/example_input_cycle_1.tif
+    channel names: DAPI, FITC, Cy3, Cy5
+    output mode: multichannel
+
+moving images:
+- filename: 20220413/example_input_cycle_2.tif
+  channel names: DAPI, FITC, Cy3, Cy5
+  output mode: multichannel
+- filename: 20220413/example_input_cycle_3.tif
+  channel names: DAPI, FITC, Cy3, Cy5
+  output mode: multichannel
+```
+
+To show the configuration schema, run the following command
+
+```bash
+palom-cycif show schema
+```
+
+As previously described, a helper script is used to generate the configuration file for running Palom on files. 
+
+Multichannel images should be in stacks based on cycles (e.g. as it would be in CycIF) in the data folder with the following layout
+
+```
+"Y:/user/me/projects/data/cycif/raw"
+    211208_IMT_m102119_02_20x_cycle1.tif
+    211208_IMT_m102119_02_20x_cycle2.tif
+    211208_IMT_m102119_02_20x_cycle3.tif
+```
+
+Running the following command would generate the configuration file
+
+```bash
+palom-cycif-helper -i "Y:/user/me/projects/data/cycif/raw" -n "*cycle1*" -o "Y:/user/me/projects/data/cycif/palom/mosaic.ome.tiff" -c "Y:/user/me/projects/data/cycif/palom/config.yaml"
+```
+
+And running the `palom-cycif` command on the resulting configuration file would produce the output mosaic `ome.tiff` file.
+
+```bash
+palom-cycif run -c "Y:/user/me/projects/data/cycif/palom/config.yaml"
+```
+
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ import palom
 # reference image is a multichannel immunofluoroscence imaging
 c1r = palom.reader.OmePyramidReader(r"Z:\P37_Pilot2\P37_S12_Full.ome.tiff")
 # moving image is a brightfield imaging (H&E staining) of the same tissue
-# section the as reference image; 
+# section as the reference image
 c2r = palom.reader.OmePyramidReader(r"Z:\P37_Pilot2\HE\P37_S12_E033_93_HE.ome.tiff")
 
 # use second-to-the-bottom pyramid level for a quick test; set `LEVEL = 0` for
@@ -234,13 +234,13 @@ c2r = palom.reader.OmePyramidReader(r"Z:\P37_Pilot2\HE\P37_S12_E033_93_HE.ome.ti
 LEVEL = 1
 # choose thumbnail pyramid level for feature-based affine registration as
 # initial coarse alignment
-# if don't know which level to use for thumbnail, `THUMBNAIL_LEVEL =
-# c1r.get_thumbnail_level_of_size(2000)` could be a good starting point
+# `THUMBNAIL_LEVEL = c1r.get_thumbnail_level_of_size(2000)` might be a good
+# starting point
 THUMBNAIL_LEVEL = 3
 
 c21l = palom.align.Aligner(
-    # use the first channel (Hoechst staining) in the reference image as
-    # reference
+    # use the first channel (Hoechst staining) in the reference image as the
+    # registration reference
     ref_img=c1r.read_level_channels(LEVEL, 0),
     # use the second channel (G channel) in the moving image, it usually has
     # better contrast
@@ -248,8 +248,8 @@ c21l = palom.align.Aligner(
     # select the same channels for the thumbnail images
     ref_thumbnail=c1r.read_level_channels(THUMBNAIL_LEVEL, 0).compute(),
     moving_thumbnail=c2r.read_level_channels(THUMBNAIL_LEVEL, 1).compute(),
-    # specify the downsizing factors so that the affine matrix can be scaled
-    # back to the pyramid at `LEVEL`
+    # specify the downsizing factors so that the affine matrix can be scaled to
+    # match the registration reference
     ref_thumbnail_down_factor=c1r.level_downsamples[THUMBNAIL_LEVEL] / c1r.level_downsamples[LEVEL],
     moving_thumbnail_down_factor=c2r.level_downsamples[THUMBNAIL_LEVEL] / c2r.level_downsamples[LEVEL]
 )
@@ -263,8 +263,8 @@ c21l.compute_shifts()
 # background regions; this is needed for WSI but maybe not for ROI images
 c21l.constrain_shifts()
 
-# configure the transformation of aligning the moving image to the reference
-# image
+# configure the transformation of aligning the moving image to the registration
+# reference
 c2m = palom.align.block_affine_transformed_moving_img(
     ref_img=c1r.read_level_channels(LEVEL, 0),
     # select all the three channels (RGB) in moving image to transform

--- a/palom/align.py
+++ b/palom/align.py
@@ -88,7 +88,7 @@ def block_affine_matrices(mx, shifts):
         y, x = shift
         mx_shift = np.eye(3)
         mx_shift[:2, 2] = x, y
-        return mx @ mx_shift
+        return mx_shift @ mx
 
     mxs = [
         shift_affine_mx(mx, s)

--- a/palom/cli/svs.py
+++ b/palom/cli/svs.py
@@ -244,6 +244,66 @@ def run_palom(
     )
     return 0
 
+# modified run_palom function to work on CycIF images:
+def run_palom_cycif(
+    img_paths,
+    pixel_size,
+    channel_names,
+    output_path,
+    level
+):
+    ref_reader = palom.reader.OmePyramidReader(img_paths[0])
+    ref_thumbnail_level = ref_reader.get_thumbnail_level_of_size(2500)
+
+    block_affines = []
+    for idx, p in enumerate(img_paths[1:]):
+        if p == img_paths[0]:
+            block_affines.append(np.eye(3))
+            continue
+        moving_reader = palom.reader.OmePyramidReader(p)
+        moving_thumbnail_level = moving_reader.get_thumbnail_level_of_size(2500)
+
+        aligner = palom.align.Aligner(
+            ref_reader.read_level_channels(level, 0),
+            moving_reader.read_level_channels(level, 0),
+            ref_reader.read_level_channels(ref_thumbnail_level, 0).compute(),
+            moving_reader.read_level_channels(moving_thumbnail_level, 0).compute(),
+            ref_reader.level_downsamples[ref_thumbnail_level] / ref_reader.level_downsamples[level],
+            moving_reader.level_downsamples[moving_thumbnail_level] / moving_reader.level_downsamples[level]
+        )
+
+        aligner.coarse_register_affine()        
+        aligner.compute_shifts()
+        aligner.constrain_shifts()
+
+        block_affines.append(aligner.block_affine_matrices_da)
+    
+    mosaics = []
+
+    for p, mx in zip(img_paths[1:], block_affines):
+        moving_reader = palom.reader.OmePyramidReader(p)
+        m_moving = palom.align.block_affine_transformed_moving_img(
+            ref_reader.read_level_channels(level, 0),
+            moving_reader.pyramid[level],
+            mx
+        )
+        mosaics.append(m_moving)
+
+    if pixel_size is None:
+        pixel_size = ref_reader.pixel_size
+
+    palom.pyramid.write_pyramid(
+        palom.pyramid.normalize_mosaics([
+            ref_reader.read_level_channels(level, [0, 1, 2, 3]),
+            mosaics[0],
+            mosaics[1]
+        ]),
+        output_path,
+        pixel_size=pixel_size,
+        channel_names=channel_names
+    )
+    return 0
+
 
 def validate_output_path(out_path, overwrite=True):
     # write access

--- a/palom/cli/svs.py
+++ b/palom/cli/svs.py
@@ -244,66 +244,6 @@ def run_palom(
     )
     return 0
 
-# modified run_palom function to work on CycIF images:
-def run_palom_cycif(
-    img_paths,
-    pixel_size,
-    channel_names,
-    output_path,
-    level
-):
-    ref_reader = palom.reader.OmePyramidReader(img_paths[0])
-    ref_thumbnail_level = ref_reader.get_thumbnail_level_of_size(2500)
-
-    block_affines = []
-    for idx, p in enumerate(img_paths[1:]):
-        if p == img_paths[0]:
-            block_affines.append(np.eye(3))
-            continue
-        moving_reader = palom.reader.OmePyramidReader(p)
-        moving_thumbnail_level = moving_reader.get_thumbnail_level_of_size(2500)
-
-        aligner = palom.align.Aligner(
-            ref_reader.read_level_channels(level, 0),
-            moving_reader.read_level_channels(level, 0),
-            ref_reader.read_level_channels(ref_thumbnail_level, 0).compute(),
-            moving_reader.read_level_channels(moving_thumbnail_level, 0).compute(),
-            ref_reader.level_downsamples[ref_thumbnail_level] / ref_reader.level_downsamples[level],
-            moving_reader.level_downsamples[moving_thumbnail_level] / moving_reader.level_downsamples[level]
-        )
-
-        aligner.coarse_register_affine()        
-        aligner.compute_shifts()
-        aligner.constrain_shifts()
-
-        block_affines.append(aligner.block_affine_matrices_da)
-    
-    mosaics = []
-
-    for p, mx in zip(img_paths[1:], block_affines):
-        moving_reader = palom.reader.OmePyramidReader(p)
-        m_moving = palom.align.block_affine_transformed_moving_img(
-            ref_reader.read_level_channels(level, 0),
-            moving_reader.pyramid[level],
-            mx
-        )
-        mosaics.append(m_moving)
-
-    if pixel_size is None:
-        pixel_size = ref_reader.pixel_size
-
-    palom.pyramid.write_pyramid(
-        palom.pyramid.normalize_mosaics([
-            ref_reader.read_level_channels(level, [0, 1, 2, 3]),
-            mosaics[0],
-            mosaics[1]
-        ]),
-        output_path,
-        pixel_size=pixel_size,
-        channel_names=channel_names
-    )
-    return 0
-
 
 def validate_output_path(out_path, overwrite=True):
     # write access

--- a/palom/pyramid.py
+++ b/palom/pyramid.py
@@ -110,14 +110,16 @@ def write_pyramid(
     pixel_size=1,
     channel_names=None,
     verbose=True,
+    downscale_factor=4
 ):
     ref_m = mosaics[0]
     path = output_path
     num_channels = count_num_channels(mosaics)
     base_shape = ref_m.shape[1:3]
-    downscale_factor = 4
+    assert int(downscale_factor) == downscale_factor
+    assert downscale_factor < min(base_shape)
     pyramid_setting = PyramidSetting(
-        downscale_factor=downscale_factor,
+        downscale_factor=int(downscale_factor),
         tile_size=max(ref_m.chunksize)
     )
     num_levels = pyramid_setting.num_levels(base_shape)

--- a/palom/register.py
+++ b/palom/register.py
@@ -154,7 +154,7 @@ def match_bf_fl_histogram(img1, img2):
         for i in (img1, img2)
     ]
     if bf1 == bf2:
-        return img1, img2
+        return img1, skimage.exposure.match_histograms(img2, img1)
     elif bf1 is True:
         return img1, skimage.exposure.match_histograms(-img2, img1)
     elif bf2 is True:

--- a/palom/register.py
+++ b/palom/register.py
@@ -149,15 +149,15 @@ def feature_based_registration(
 def match_bf_fl_histogram(img1, img2):
     img1 = img1.astype(np.float32)
     img2 = img2.astype(np.float32)
-    bf1, bf2 = [
+    is_bf_img1, is_bf_img2 = [
         img_util.is_brightfield_img(i) 
         for i in (img1, img2)
     ]
-    if bf1 == bf2:
+    if is_bf_img1 == is_bf_img2:
         return img1, skimage.exposure.match_histograms(img2, img1)
-    elif bf1 is True:
+    elif is_bf_img1:
         return img1, skimage.exposure.match_histograms(-img2, img1)
-    elif bf2 is True:
+    elif is_bf_img2:
         return skimage.exposure.match_histograms(-img1, img2), img2
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "palom"
-version = "2021.12.0"
+version = "2022.02.0"
 description = "Piecewise alignment for layers of mosaics"
 authors = ["Yu-An Chen <atwood12@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "palom"
-version = "2022.3.1"
+version = "2022.3.2"
 description = "Piecewise alignment for layers of mosaics"
 authors = ["Yu-An Chen <atwood12@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "palom"
-version = "2022.02.0"
+version = "2022.02.1"
 description = "Piecewise alignment for layers of mosaics"
 authors = ["Yu-An Chen <atwood12@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "palom"
-version = "2022.3.2"
+version = "2022.3.3"
 description = "Piecewise alignment for layers of mosaics"
 authors = ["Yu-An Chen <atwood12@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "palom"
-version = "2022.02.1"
+version = "2022.3.1"
 description = "Piecewise alignment for layers of mosaics"
 authors = ["Yu-An Chen <atwood12@gmail.com>"]
 readme = "README.md"
@@ -21,7 +21,8 @@ python = ">=3.7.8,<3.8"
 scikit-image = "^0.18.3"
 scikit-learn = "^0.24.2"
 opencv-python = "^4.5.3.56"
-zarr = "^2.10.0"
+# Pin zarr version until resolve issues when using Zarr v2.11
+zarr = "~2.10.0"
 tifffile = "^2021.10.12"
 matplotlib = "^3.4.3"
 tqdm = "^4.62.3"


### PR DESCRIPTION
Added cycif.py script based on the svs.py script to run Palom on CycIF images - TIF files, multiple cycles, multiple channels, registration based on the nuclear channel.
Added helper_cycif.py script based on the helper.py script to produce configuration yaml file for CLI.
Added schemas for CycIF data.
Added CLI usage.
Updated README to explain usage of adapted functions.

